### PR TITLE
Update Lambda environment variables and memory configuration

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -57,6 +57,12 @@ Resources:
       CodeUri: ./lambdas/add
       Description: Add
       AutoPublishAlias: live
+      MemorySize: 256
+      Timeout: 30
+      Environment:
+        Variables:
+          LOG_LEVEL: INFO
+          ENVIRONMENT: production
 
   CleanInputLambdaFunction:
     Type: AWS::Serverless::Function
@@ -66,6 +72,12 @@ Resources:
       CodeUri: ./lambdas/cleaninput
       Description: Clean Input
       AutoPublishAlias: live
+      MemorySize: 256
+      Timeout: 30
+      Environment:
+        Variables:
+          LOG_LEVEL: INFO
+          ENVIRONMENT: production
 
   DivideLambdaFunction:
     Type: AWS::Serverless::Function
@@ -75,6 +87,12 @@ Resources:
       CodeUri: ./lambdas/divide
       Description: Divide
       AutoPublishAlias: live
+      MemorySize: 256
+      Timeout: 30
+      Environment:
+        Variables:
+          LOG_LEVEL: INFO
+          ENVIRONMENT: production
 
   MultiplyLambdaFunction:
     Type: AWS::Serverless::Function
@@ -84,6 +102,12 @@ Resources:
       CodeUri: ./lambdas/multiply
       Description: Multiply
       AutoPublishAlias: live
+      MemorySize: 256
+      Timeout: 30
+      Environment:
+        Variables:
+          LOG_LEVEL: INFO
+          ENVIRONMENT: production
 
   SubtractLambdaFunction:
     Type: AWS::Serverless::Function
@@ -93,6 +117,12 @@ Resources:
       CodeUri: ./lambdas/subtract
       Description: Subtract
       AutoPublishAlias: live
+      MemorySize: 256
+      Timeout: 30
+      Environment:
+        Variables:
+          LOG_LEVEL: INFO
+          ENVIRONMENT: production
 
   StateMachine:
     Type: AWS::Serverless::StateMachine


### PR DESCRIPTION
This PR enhances the Lambda functions configuration by adding:

- **Memory Size**: Increased from default 128 MB to 256 MB for better performance
- **Timeout**: Set to 30 seconds (from default 3 seconds) to handle longer operations
- **Environment Variables**: 
  - LOG_LEVEL: INFO for consistent logging
  - ENVIRONMENT: production for environment-specific behavior

These changes improve:
- Performance with increased memory allocation
- Reliability with appropriate timeout settings
- Observability with structured logging
- Configuration management with environment variables

All 5 Lambda functions (Add, CleanInput, Divide, Multiply, Subtract) have been updated consistently.