### PR TITLE
Modify Lambda functions to handle increased concurrent executions

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -69,7 +69,8 @@ Resources:
       CodeUri: ./lambdas/add
       Description: Add
       AutoPublishAlias: live
-      ReservedConcurrency: 100
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrencyExecutions: 10
 
   CleanInputLambdaFunction:
     Type: AWS::Serverless::Function
@@ -79,7 +80,6 @@ Resources:
       CodeUri: ./lambdas/cleaninput
       Description: Clean Input
       AutoPublishAlias: live
-      ReservedConcurrency: 50
 
   DivideLambdaFunction:
     Type: AWS::Serverless::Function
@@ -89,7 +89,6 @@ Resources:
       CodeUri: ./lambdas/divide
       Description: Divide
       AutoPublishAlias: live
-      ReservedConcurrency: 50
 
   MultiplyLambdaFunction:
     Type: AWS::Serverless::Function
@@ -99,7 +98,6 @@ Resources:
       CodeUri: ./lambdas/multiply
       Description: Multiply
       AutoPublishAlias: live
-      ReservedConcurrency: 50
 
   SubtractLambdaFunction:
     Type: AWS::Serverless::Function
@@ -109,7 +107,6 @@ Resources:
       CodeUri: ./lambdas/subtract
       Description: Subtract
       AutoPublishAlias: live
-      ReservedConcurrency: 50
 
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/template.yaml
+++ b/template.yaml
@@ -69,7 +69,7 @@ Resources:
       CodeUri: ./lambdas/add
       Description: Add
       AutoPublishAlias: live
-      ReservedConcurrencyLimit: 100
+      ReservedConcurrency: 100
 
   CleanInputLambdaFunction:
     Type: AWS::Serverless::Function
@@ -79,7 +79,7 @@ Resources:
       CodeUri: ./lambdas/cleaninput
       Description: Clean Input
       AutoPublishAlias: live
-      ReservedConcurrencyLimit: 50
+      ReservedConcurrency: 50
 
   DivideLambdaFunction:
     Type: AWS::Serverless::Function
@@ -89,7 +89,7 @@ Resources:
       CodeUri: ./lambdas/divide
       Description: Divide
       AutoPublishAlias: live
-      ReservedConcurrencyLimit: 50
+      ReservedConcurrency: 50
 
   MultiplyLambdaFunction:
     Type: AWS::Serverless::Function
@@ -99,7 +99,7 @@ Resources:
       CodeUri: ./lambdas/multiply
       Description: Multiply
       AutoPublishAlias: live
-      ReservedConcurrencyLimit: 50
+      ReservedConcurrency: 50
 
   SubtractLambdaFunction:
     Type: AWS::Serverless::Function
@@ -109,7 +109,7 @@ Resources:
       CodeUri: ./lambdas/subtract
       Description: Subtract
       AutoPublishAlias: live
-      ReservedConcurrencyLimit: 50
+      ReservedConcurrency: 50
 
   StateMachine:
     Type: AWS::Serverless::StateMachine

--- a/template.yaml
+++ b/template.yaml
@@ -69,6 +69,7 @@ Resources:
       CodeUri: ./lambdas/add
       Description: Add
       AutoPublishAlias: live
+      ReservedConcurrencyLimit: 100
 
   CleanInputLambdaFunction:
     Type: AWS::Serverless::Function
@@ -78,6 +79,7 @@ Resources:
       CodeUri: ./lambdas/cleaninput
       Description: Clean Input
       AutoPublishAlias: live
+      ReservedConcurrencyLimit: 50
 
   DivideLambdaFunction:
     Type: AWS::Serverless::Function
@@ -87,6 +89,7 @@ Resources:
       CodeUri: ./lambdas/divide
       Description: Divide
       AutoPublishAlias: live
+      ReservedConcurrencyLimit: 50
 
   MultiplyLambdaFunction:
     Type: AWS::Serverless::Function
@@ -96,6 +99,7 @@ Resources:
       CodeUri: ./lambdas/multiply
       Description: Multiply
       AutoPublishAlias: live
+      ReservedConcurrencyLimit: 50
 
   SubtractLambdaFunction:
     Type: AWS::Serverless::Function
@@ -105,6 +109,7 @@ Resources:
       CodeUri: ./lambdas/subtract
       Description: Subtract
       AutoPublishAlias: live
+      ReservedConcurrencyLimit: 50
 
   StateMachine:
     Type: AWS::Serverless::StateMachine


### PR DESCRIPTION
- Sets ReservedConcurrencyLimit to 100 for AddLambdaFunction (main function)
- Sets ReservedConcurrencyLimit to 50 for other Lambda functions
- Ensures predictable performance under high load